### PR TITLE
Refactor: Update Learning Hub frontend components

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -82,12 +82,6 @@ const HeroSection = React.forwardRef<HTMLDivElement, HeroSectionProps>(
                 {title}
                 <ChevronRight className="inline w-4 h-4 ml-1 group-hover:translate-x-1 duration-300" />
               </h1>
-              <h2 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl">
-                <span className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-800 bg-clip-text text-transparent">
-                  {subtitle.regular}
-                  {subtitle.gradient}
-                </span>
-              </h2>
               <p className="max-w-2xl mx-auto text-gray-600 text-lg">
                 {description}
               </p>
@@ -106,6 +100,12 @@ const HeroSection = React.forwardRef<HTMLDivElement, HeroSectionProps>(
                   </div>
                 </span>
               </div>
+              <h2 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl mt-8">
+                <span className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-800 bg-clip-text text-transparent">
+                  {subtitle.regular}
+                  {subtitle.gradient}
+                </span>
+              </h2>
             </div>
           </div>
         </section>

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -23,19 +23,6 @@ const SearchBar = () => {
               Search
             </button>
           </div>
-          <div className="px-4 py-2 border-t border-gray-100">
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-gray-500">Nearby:</span>
-              {['City Central Library', 'University Library', 'Community Library', 'Public Library'].map((tag) => (
-                <button
-                  key={tag}
-                  className="px-3 py-1 text-blue-700 hover:bg-blue-50 rounded-full transition-colors"
-                >
-                  {tag}
-                </button>
-              ))}
-            </div>
-          </div>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
This commit addresses several UI and content updates for the Learning Hub page:

- Spelling: I confirmed "Hub" (not "HUB") is the correct and current usage in "Welcome to The Learning Hub". No changes were needed as the existing code was already correct.
- Search Bar: I kept the search bar section as you requested.
- Remove Nearby Links: I removed the "Nearby: City Central Library, University Library..." links from the SearchBar component.
- Below Line: I moved the "Physical Space, Digital Learning" subtitle to appear below the "Get Started" button in the HeroSection component.
- UI Clean-up: I added a top margin to the moved subtitle to ensure neat alignment and visual spacing.