### PR TITLE
Fix: Correct Learning Hub logo and adjust hero layout

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -85,6 +85,15 @@ const HeroSection = React.forwardRef<HTMLDivElement, HeroSectionProps>(
               <p className="max-w-2xl mx-auto text-gray-600 text-lg">
                 {description}
               </p>
+              <h2 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl text-center">
+                <span className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-800 bg-clip-text text-transparent">
+                  {subtitle.regular}
+                </span>
+                <br />
+                <span className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-800 bg-clip-text text-transparent">
+                  {subtitle.gradient}
+                </span>
+              </h2>
               <div className="items-center justify-center gap-x-3 space-y-3 sm:flex sm:space-y-0 mt-8">
                 <span className="relative inline-block overflow-hidden rounded-full p-[1.5px]">
                   <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#1e40af_0%,#1d4ed8_50%,#1e40af_100%)]" />
@@ -100,12 +109,6 @@ const HeroSection = React.forwardRef<HTMLDivElement, HeroSectionProps>(
                   </div>
                 </span>
               </div>
-              <h2 className="text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl mt-8">
-                <span className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-800 bg-clip-text text-transparent">
-                  {subtitle.regular}
-                  {subtitle.gradient}
-                </span>
-              </h2>
             </div>
           </div>
         </section>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -70,9 +70,7 @@ const Navbar = () => {
                 className="w-auto h-12"
               />
             </motion.div>
-            <span className="text-blue-700 font-bold text-lg">
-              The Learning HUB
-            </span>
+            <span className="text-blue-700 font-bold text-lg">The Learning Hub</span>
             <div className="hidden md:block">
               <div className="ml-10 flex items-center space-x-4">
                 <NavLink href="/">Home</NavLink>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
       <HeroSection
         title="Welcome to The Learning Hub"
         subtitle={{
-          regular: "Physical Space, ",
+          regular: "Physical Space",
           gradient: "Digital Learning",
         }}
         description="Utilise your empty space and transform into Learning Hub"


### PR DESCRIPTION
This commit addresses your feedback on previous UI updates:

- Navbar: Corrected "The Learning HUB" to "The Learning Hub" in the Navbar logo text.
- Hero Section:
    - Modified the subtitle "Physical Space, Digital Learning" to remove the comma and display "Physical Space" on one line and "Digital Learning" directly below it.
    - Repositioned the "Get Started" button to be directly underneath this two-line subtitle for improved visual hierarchy and alignment.