### PR TITLE
Fix: Update footer tagline and address details

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
     },
     {
       icon: MapPin,
-      text: "123 Learning Street, Education City, IN 400001",
+      text: "GT Road, Gopiganj, Bhadohi",
       href: "https://maps.google.com",
     },
   ];
@@ -51,7 +51,7 @@ export function Footer() {
               </div>
               <div>
                 <h3 className="text-xl font-bold">The Learning Hub</h3>
-                <p className="text-sm text-slate-400">Empowering Education</p>
+                <p className="text-sm text-slate-400">Physical Space, Digital Learning</p>
               </div>
             </div>
             <p className="text-slate-400 text-sm leading-relaxed">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -152,7 +152,7 @@ export default function ContactPage() {
                     <div>
                       <h3 className="font-medium text-slate-900">Address</h3>
                       <p className="text-slate-600">
-                        123 Learning Street, Education City, IN 400001
+                        GT Road, Gopiganj, Bhadohi
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
Updates the footer tagline and address information in both the footer and the contact page as per your request.

- Footer:
    - Tagline changed from "Empowering Education" to "Physical Space, Digital Learning".
    - Address updated to "GT Road, Gopiganj, Bhadohi". The generic Google Maps link is retained.
- Contact Page:
    - Address updated to "GT Road, Gopiganj, Bhadohi". The existing embedded Google Map is retained.