### PR TITLE
Fix: Update embedded Google Map on Contact Page

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -187,7 +187,7 @@ export default function ContactPage() {
                 <h2 className="text-2xl font-bold mb-6">Location</h2>
                 <div className="aspect-video rounded-lg overflow-hidden">
                   <iframe
-                    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3771.0556933781763!2d72.8282143!3d19.0759837!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zMTnCsDA0JzMzLjUiTiA3MsKwNDknNDEuNiJF!5e0!3m2!1sen!2sin!4v1635000000000!5m2!1sen!2sin"
+                    src="https://www.google.com/maps/embed?pb=!1m17!1m12!1m3!1d3607.2283182592478!2d82.408504!3d25.296532!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m2!1m1!2zMjXCsDE3JzQ3LjUiTiA4MsKwMjQnMzAuNiJF!5e0!3m2!1sen!2sin!4v1749356898536!5m2!1sen!2sin"
                     width="100%"
                     height="100%"
                     style={{ border: 0 }}


### PR DESCRIPTION
Updates the `src` attribute of the embedded Google Map iframe on the contact page to a new location as specified by you.

The map retains its responsive styling (width="100%", height="100%") to fit within its container.